### PR TITLE
fix(ci): build from repo root instead of plugin dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Build plugin
         run: |
-          cd plugin
           npm install
           npm run build
 


### PR DESCRIPTION
Adjust CI release workflow to stop changing directories into the
plugin subfolder before installing and building. The workflow now
runs npm install and npm run build from the repository root.

This simplifies the workflow and avoids directory state issues that
could break subsequent steps or hide workspace-level dependencies.