### PR TITLE
feat: add script to copy build to local Obsidian vault

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to `.env` and fill in the values
+# VAULT_PATH is the absolute path to your Obsidian vault where you want to copy
+# the generated markdown files. Make sure to use forward slashes (/) or double backslashes (\\)
+VAULT_PATH = '/path/to/your/obsidian/vault'

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# Environment variables file
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@floating-ui/react": "^0.26.4",
 				"@types/uuid": "^9.0.7",
+				"dotenv": "^17.2.3",
 				"lucide-react": "^0.303.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -1391,6 +1392,18 @@
 			"dependencies": {
 				"@babel/runtime": "^7.8.7",
 				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "17.2.3",
+			"resolved": "https://registry.npmmirror.com/dotenv/-/dotenv-17.2.3.tgz",
+			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/error-ex": {
@@ -3710,6 +3723,11 @@
 				"@babel/runtime": "^7.8.7",
 				"csstype": "^3.0.2"
 			}
+		},
+		"dotenv": {
+			"version": "17.2.3",
+			"resolved": "https://registry.npmmirror.com/dotenv/-/dotenv-17.2.3.tgz",
+			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="
 		},
 		"error-ex": {
 			"version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"build:local": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production && node scripts/copy-to-vault.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],
@@ -28,6 +29,7 @@
 	"dependencies": {
 		"@floating-ui/react": "^0.26.4",
 		"@types/uuid": "^9.0.7",
+		"dotenv": "^17.2.3",
 		"lucide-react": "^0.303.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/scripts/copy-to-vault.mjs
+++ b/scripts/copy-to-vault.mjs
@@ -1,0 +1,88 @@
+import dotenv from "dotenv";
+import { existsSync } from "fs";
+import { copyFile, mkdir, readFile } from "fs/promises";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, "..");
+
+dotenv.config({ quiet: true });
+const VAULT_PATH = process.env.VAULT_PATH;
+if (!VAULT_PATH) {
+	throw new Error(
+		"VAULT_PATH is not defined. Please create a .env file in the project root and add the line: VAULT_PATH=/path/to/your/vault"
+	);
+}
+
+const fileConfig = [
+	{
+		name: "manifest.json",
+		sourcePath: projectRoot,
+	},
+	{
+		name: "main.js",
+		sourcePath: projectRoot,
+	},
+	{
+		name: "styles.css",
+		sourcePath: projectRoot,
+	},
+];
+
+async function copyToVault() {
+	try {
+		// 获取 manifest.json 配置，从 fileConfig 中找到对应文件
+		const manifestConfig = fileConfig.find(
+			(file) => file.name === "manifest.json"
+		);
+		if (!manifestConfig) {
+			throw new Error("manifest.json not found in fileConfig");
+		}
+
+		const manifestPath = join(
+			manifestConfig.sourcePath,
+			manifestConfig.name
+		);
+		const manifestContent = await readFile(manifestPath, "utf8");
+		const manifest = JSON.parse(manifestContent);
+		const pluginId = manifest.id;
+
+		if (!pluginId) {
+			throw new Error("Plugin ID not found in manifest.json");
+		}
+
+		const targetPluginDir = join(
+			VAULT_PATH,
+			".obsidian",
+			"plugins",
+			pluginId
+		);
+
+		if (!existsSync(targetPluginDir)) {
+			await mkdir(targetPluginDir, { recursive: true });
+			console.log(`创建目录: ${targetPluginDir}`);
+		}
+
+		// 复制文件
+		for (const fileInfo of fileConfig) {
+			const sourcePath = join(fileInfo.sourcePath, fileInfo.name);
+			const destPath = join(targetPluginDir, fileInfo.name);
+
+			if (!existsSync(sourcePath)) {
+				console.warn(`警告: 源文件不存在 ${sourcePath}`);
+				continue;
+			}
+
+			await copyFile(sourcePath, destPath);
+			// console.log(`复制文件: ${fileInfo.name} -> ${destPath}`);
+		}
+
+		console.log(`插件 ${pluginId} 已成功复制到 vault`);
+	} catch (error) {
+		console.error("复制文件时出错:", error);
+		process.exit(1);
+	}
+}
+
+copyToVault();


### PR DESCRIPTION
Add scripts/copy-to-vault.mjs to read manifest.json, create the
target plugin directory in a configured Obsidian vault, and copy
built files (manifest.json, main.js, styles.css) into that plugin
folder. Fail early with a clear error if VAULT_PATH is not set.

Add a build:local script to package.json that runs the production
build and then invokes the new copy-to-vault script for a one-step
local deployment workflow.

Include dotenv as a dependency and provide .env.example plus .env
in .gitignore so developers can configure VAULT_PATH without
committing secrets. Update package-lock to include dotenv.

This streamlines local testing by automatically installing the
latest build into a local Obsidian vault.