### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "attachment-pro",
 	"name": "Attachment Pro",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"minAppVersion": "0.13.0",
 	"description": "your last obsidian attachment plugin",
 	"author": "vran",


### PR DESCRIPTION
Update manifest to increment the plugin version from 0.3.0 to
0.3.1. This reflects a new patch release for Attachment Pro and
ensures the host app recognizes the updated build.