### PR TITLE
fix(attachments): handle frontmatter tags type variations

### DIFF
--- a/src/manager/scope/fileTagAttachmentScopeMatcher.ts
+++ b/src/manager/scope/fileTagAttachmentScopeMatcher.ts
@@ -21,7 +21,7 @@ export default class FileTagAttachmentScopeMatcher
 		}
 
 		// merge tags from content
-		const allTags = [];
+		const allTags: string[] = [];
 		if (fileCache.tags) {
 			const tags = fileCache.tags.map((t) => t.tag.substring(1));
 			// obsidian tag starts with #, so we need to remove it
@@ -31,7 +31,11 @@ export default class FileTagAttachmentScopeMatcher
 		// merge tags from frontmatter
 		if (fileCache.frontmatter) {
 			const tags = fileCache.frontmatter["tags"];
-			allTags.push(...tags);
+			if (Array.isArray(tags)) {
+				allTags.push(...tags.map(String));
+			} else if (typeof tags === "string") {
+				allTags.push(...tags.split(",").map((t) => t.trim()));
+			}
 		}
 
 		if (scope.operator === "CONTAINS_ALL") {


### PR DESCRIPTION
## 背景
`fileTagAttachmentScopeMatcher` 读取 frontmatter `tags` 字段时直接展开，但该字段可能是数组、逗号分隔字符串或其他类型，非数组时会触发运行时错误。

## 改动
- 增加类型判断：数组直接展开（并 `map(String)`），字符串按逗号分隔后展开，其他类型忽略

## 影响
- 纯 bug 修复，无破坏性变更，可独立合入