### PR TITLE
fix: resolve settings/attachment defects and replace eval with controlled evaluator

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "attachment-pro",
 	"name": "Attachment Pro",
 	"version": "0.3.1",
-	"minAppVersion": "0.13.0",
+	"minAppVersion": "1.11.0",
 	"description": "your last obsidian attachment plugin",
 	"author": "vran",
 	"authorUrl": "https://github.com/vran-dev",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"dev": "node --env-file-if-exists=.env scripts/deploy.mjs link && node scripts/esbuild.config.mjs dev",
 		"build": "tsc -noEmit -skipLibCheck && node scripts/esbuild.config.mjs prod && node --env-file-if-exists=.env scripts/deploy.mjs copy",
-		"release": "pnpm run build && node scripts/version-bump.mjs && pnpm i"
+		"release": "pnpm run build && node scripts/version-bump.mjs && pnpm i",
+		"lint": "eslint src/"
 	},
 	"keywords": [
 		"Obsidian Plugin"
@@ -14,6 +15,7 @@
 	"author": "vran",
 	"license": "MIT",
 	"devDependencies": {
+		"@eslint/js": "^10.0.1",
 		"@types/luxon": "^3.7.2",
 		"@types/node": "^25.9.1",
 		"@types/react": "^18.3.29",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^14.0.1
         version: 14.0.1
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.7.0)
       '@types/luxon':
         specifier: ^3.7.2
         version: 3.7.2
@@ -59,7 +62,7 @@ importers:
         version: 10.7.0
       eslint-plugin-obsidianmd:
         specifier: ^0.3.0
-        version: 0.3.0(@eslint/js@9.39.5)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.65.0(eslint@10.7.0)(typescript@5.9.3))
+        version: 0.3.0(@eslint/js@10.0.1(eslint@10.7.0))(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.65.0(eslint@10.7.0)(typescript@5.9.3))
       globals:
         specifier: ^17.6.0
         version: 17.7.0
@@ -377,9 +380,14 @@ packages:
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/js@9.39.5':
-    resolution: {integrity: sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/json@0.14.0':
     resolution: {integrity: sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==}
@@ -1999,7 +2007,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@9.39.5': {}
+  '@eslint/js@10.0.1(eslint@10.7.0)':
+    optionalDependencies:
+      eslint: 10.7.0
 
   '@eslint/json@0.14.0':
     dependencies:
@@ -2737,10 +2747,10 @@ snapshots:
     dependencies:
       eslint: 10.7.0
 
-  eslint-plugin-obsidianmd@0.3.0(@eslint/js@9.39.5)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.65.0(eslint@10.7.0)(typescript@5.9.3)):
+  eslint-plugin-obsidianmd@0.3.0(@eslint/js@10.0.1(eslint@10.7.0))(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.65.0(eslint@10.7.0)(typescript@5.9.3)):
     dependencies:
       '@eslint/config-helpers': 0.4.2
-      '@eslint/js': 9.39.5
+      '@eslint/js': 10.0.1(eslint@10.7.0)
       '@eslint/json': 0.14.0
       '@microsoft/eslint-plugin-sdl': 1.1.0(eslint@10.7.0)
       '@types/eslint': 9.6.1

--- a/scripts/esbuild.config.mjs
+++ b/scripts/esbuild.config.mjs
@@ -172,9 +172,6 @@ const context = await esbuild.context({
 	outdir: outDir,
 	minify: prod,
 	drop: prod ? ["console"] : [],
-	logOverride: {
-		"direct-eval": "silent"
-	}
 });
 
 // 初始构建时复制 manifest.json

--- a/src/event/editorPasteOrDropHandler.ts
+++ b/src/event/editorPasteOrDropHandler.ts
@@ -13,27 +13,30 @@ import { log } from "src/util/log";
 export default class EditorPasteOrDropHandler {
 	attachmentManager = new AttachmentManager();
 
+	/**
+	 * @returns true 表示事件已由本插件处理,调用方需要 preventDefault
+	 */
 	on(
 		evt: ClipboardEvent | DragEvent,
 		editor: Editor,
 		info: MarkdownView | MarkdownFileInfo,
 		plugin: AttachmentProPlugin
-	) {
+	): boolean {
 		const dataItems = this.getDataTransferItem(evt);
 		if (!dataItems) {
 			log("[Event] ignoresd no data items");
-			return;
+			return false;
 		}
 
 		if (isAllStringType(dataItems)) {
 			log("[Event] ignoresd all is string type");
-			return;
+			return false;
 		}
 
 		const pageFile = info.file;
 		if (!pageFile) {
 			log("[Event] ignoresd no active page file");
-			return;
+			return false;
 		}
 
 		log("[Event] prepare to handle " + dataItems.length + " items");
@@ -41,10 +44,9 @@ export default class EditorPasteOrDropHandler {
 		if (dataItems.length == 2 && dataItems[0].type == "text/html" && dataItems[1].kind == "file"){
 			log("[Event] found network image with string, only process the file.");
 			this.handleFile(dataItems[1], pageFile, editor, plugin, 0);
-			evt.preventDefault();
-			return;
+			return true;
 		}
-		
+
 		for (let i = dataItems.length - 1; i >= 0; i--) {
 			const item = dataItems[i];
 
@@ -55,7 +57,7 @@ export default class EditorPasteOrDropHandler {
 				this.handleString(item, editor);
 			}
 		}
-		evt.preventDefault();
+		return true;
 	}
 
 	getDataTransferItem(evt: DragEvent | ClipboardEvent) {

--- a/src/handler/attachmentsHandler.ts
+++ b/src/handler/attachmentsHandler.ts
@@ -1,26 +1,29 @@
 import { App, TFile } from "obsidian";
+import { log } from "src/util/log";
 
 export class AttachmentHandler {
 	async listUnusedAttachments(app: App): Promise<TFile[]> {
 		const startTime = Date.now();
-		
+
 		const attachments: TFile[] = await this.listAttachments(app);
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const usedAttachments: any = [];
+		// resolvedLinks 的内层 key 即被引用文件的路径，直接以路径判重，
+		// 避免 getAbstractFileByPath 返回 null 污染集合与 O(n²) 的数组 includes
+		const usedAttachmentPaths = new Set<string>();
 		const resolvedLinks = app.metadataCache.resolvedLinks;
 		if (resolvedLinks) {
-			for (const [mdFile, links] of Object.entries(resolvedLinks)){
-				for (const [filePath, nr] of Object.entries(resolvedLinks[mdFile])){
-					const file = app.vault.getAbstractFileByPath(filePath);
-					usedAttachments.push(file);
+			for (const links of Object.values(resolvedLinks)) {
+				for (const filePath of Object.keys(links)) {
+					usedAttachmentPaths.add(filePath);
 				}
 			}
 		}
 
-		const unusedAttachments: TFile[] = attachments.filter((file) =>!usedAttachments.includes(file));
+		const unusedAttachments: TFile[] = attachments.filter(
+			(file) => !usedAttachmentPaths.has(file.path)
+		);
 
 		const endTime = Date.now();
-		console.log(
+		log(
 			`[AttachmentHandler] list unused attachments cost ${
 				endTime - startTime
 			}ms`
@@ -30,17 +33,14 @@ export class AttachmentHandler {
 
 	async listAttachments(app: App): Promise<TFile[]> {
 		const startTime = Date.now();
-		
-		const allFiles : TFile[] = app.vault.getFiles();
-		const attachments: TFile[] = [];
-		for(let i = 0; i < allFiles.length; i++){
-			if(!['md', 'canvas'].includes(allFiles[i].extension)) {
-				attachments.push(allFiles[i]);
-			}
-		}
-		
+
+		const allFiles: TFile[] = app.vault.getFiles();
+		const attachments: TFile[] = allFiles.filter(
+			(file) => !["md", "canvas"].includes(file.extension)
+		);
+
 		const endTime = Date.now();
-		console.log(
+		log(
 			`[AttachmentHandler] list attachments cost ${endTime - startTime}ms`
 		);
 		return attachments;

--- a/src/i18/messages.ts
+++ b/src/i18/messages.ts
@@ -1,3 +1,4 @@
+import { getLanguage } from "obsidian";
 import EnLocalMessage from "./enLocalMessage";
 import ZhLocalMessage from "./zhLocalMessage";
 
@@ -57,9 +58,10 @@ export interface Message {
 }
 
 export function getLocal(): Message {
-	const lang = window.localStorage.getItem("language");
+	const lang = getLanguage();
 	switch (lang) {
 		case "zh":
+		case "zh-TW":
 			return new ZhLocalMessage();
 		default:
 			return new EnLocalMessage();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Notice, Plugin, CanvasView } from "obsidian";
 import { AttachmentProConfig } from "./manager/types";
+import { migrateConfig } from "./manager/migrate";
 import { DEFAULT_SETTINGS } from "./setting/defaultSetting";
 import { log } from "./util/log";
 import ReactAttachmentSettingTab from "./ui/reactSettingTab";
@@ -38,11 +39,16 @@ export default class AttachmentProPlugin extends Plugin {
 	onunload() { }
 
 	async loadSettings() {
-		this.settings = Object.assign(
+		const merged = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
+		this.settings = migrateConfig(merged);
+		if (JSON.stringify(this.settings) !== JSON.stringify(merged)) {
+			// 迁移产生了变化，落盘避免坏值残留在 data.json
+			await this.saveData(this.settings);
+		}
 		log("[Config] loading plugins", this.settings);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,12 @@ export default class AttachmentProPlugin extends Plugin {
 	registerEditorPasteHandler() {
 		this.registerEvent(
 			this.app.workspace.on("editor-paste", (evt, editor, info) => {
-				new EditorPasteOrDropHandler().on(evt, editor, info, this);
+				if (evt.defaultPrevented) {
+					return;
+				}
+				if (new EditorPasteOrDropHandler().on(evt, editor, info, this)) {
+					evt.preventDefault();
+				}
 			})
 		);
 	}
@@ -73,7 +78,12 @@ export default class AttachmentProPlugin extends Plugin {
 	registerEditorDropHandler() {
 		this.registerEvent(
 			this.app.workspace.on("editor-drop", (evt, editor, info) => {
-				new EditorPasteOrDropHandler().on(evt, editor, info, this);
+				if (evt.defaultPrevented) {
+					return;
+				}
+				if (new EditorPasteOrDropHandler().on(evt, editor, info, this)) {
+					evt.preventDefault();
+				}
 			})
 		);
 	}

--- a/src/manager/attachmentManager.ts
+++ b/src/manager/attachmentManager.ts
@@ -45,7 +45,9 @@ export default class AttachmentManager {
 		onSave: (link: AttachmentResult) => void,
 		fallback: () => void
 	) {
-		const enabledRules = config.rules.filter((r) => r.enabled);
+		const enabledRules = config.rules
+			.filter((r) => r.enabled)
+			.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
 		log("[Enabled Rules] ", enabledRules);
 
 		for (let i = 0; i < enabledRules.length; i++) {

--- a/src/manager/migrate.ts
+++ b/src/manager/migrate.ts
@@ -1,0 +1,25 @@
+import { AttachmentProConfig } from "./types";
+
+/**
+ * 配置迁移入口：每次加载配置后执行，必须保持幂等。
+ * 后续 schema 变更统一在此追加迁移逻辑。
+ *
+ * - 历史版本设置面板对「仓库根目录」写入的 repository.type 是
+ *   "VAULT_SUBFOLDER"，而仓库匹配端判断的是 "ROOT_FOLDER"，两者不一致
+ *   会导致附件被静默丢弃，这里把存量坏值统一迁移为 "ROOT_FOLDER"。
+ * - 规则数组按 sort 稳定排序，保证展示顺序与执行顺序一致。
+ */
+export function migrateConfig(raw: AttachmentProConfig): AttachmentProConfig {
+	const rules = (raw.rules ?? [])
+		.map((rule) => {
+			if ((rule.repository?.type as string | undefined) === "VAULT_SUBFOLDER") {
+				return {
+					...rule,
+					repository: { ...rule.repository, type: "ROOT_FOLDER" as const },
+				};
+			}
+			return rule;
+		})
+		.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
+	return { ...raw, debug: raw.debug ?? false, rules };
+}

--- a/src/manager/variable/expressionEvaluator.ts
+++ b/src/manager/variable/expressionEvaluator.ts
@@ -1,0 +1,140 @@
+/**
+ * 受控表达式求值器，用于替代 eval 解析 `${...}` 占位符（安全修复 P0-3）。
+ *
+ * 仅支持两种语法：
+ *   1. 属性访问：  a.b.c
+ *   2. 方法调用：  a.b('x') / a.b().c(1, true)
+ *
+ * 方法调用的参数只允许字符串/数字/布尔字面量；其余一切 JS 语法
+ * （运算符、下标访问、模板字符串、new、分号等）都会在词法或语法
+ * 阶段被拒绝，求值返回 undefined，由调用方保留原始占位符。
+ */
+
+type Token =
+	| { kind: "ident"; value: string }
+	| { kind: "string"; value: string }
+	| { kind: "number"; value: number }
+	| { kind: "boolean"; value: boolean }
+	| { kind: "dot" }
+	| { kind: "lparen" }
+	| { kind: "rparen" }
+	| { kind: "comma" };
+
+// 空白单独成 token 以便跳过；字符串字面量整体捕获，内部空白不受影响
+const TOKEN_PATTERN =
+	/\s+|'[^']*'|"[^"]*"|\d+(?:\.\d+)?|[A-Za-z_$][\w$]*|[.(),]/g;
+
+// 阻断原型链逃逸（如 file.constructor.constructor('...')）
+const BLOCKED_PROPERTIES = new Set(["__proto__", "constructor", "prototype"]);
+
+function tokenize(expr: string): Token[] | null {
+	const tokens: Token[] = [];
+	TOKEN_PATTERN.lastIndex = 0;
+	let last = 0;
+	let m: RegExpExecArray | null;
+	while ((m = TOKEN_PATTERN.exec(expr)) !== null) {
+		if (m.index !== last) {
+			return null; // 出现无法识别的字符，整体拒绝
+		}
+		last += m[0].length;
+		const s = m[0];
+		if (/^\s/.test(s)) continue;
+		if (s === ".") tokens.push({ kind: "dot" });
+		else if (s === "(") tokens.push({ kind: "lparen" });
+		else if (s === ")") tokens.push({ kind: "rparen" });
+		else if (s === ",") tokens.push({ kind: "comma" });
+		else if (s === "true" || s === "false")
+			tokens.push({ kind: "boolean", value: s === "true" });
+		else if (s[0] === "'" || s[0] === '"')
+			tokens.push({ kind: "string", value: s.slice(1, -1) });
+		else if (/^\d/.test(s)) tokens.push({ kind: "number", value: Number(s) });
+		else tokens.push({ kind: "ident", value: s });
+	}
+	return last === expr.length ? tokens : null;
+}
+
+function evaluate(tokens: Token[], root: Record<string, unknown>): unknown {
+	let i = 0;
+
+	function parseLiteral(): unknown {
+		const t = tokens[i++];
+		if (!t) throw new Error("unexpected end of expression");
+		if (t.kind === "string" || t.kind === "number" || t.kind === "boolean") {
+			return t.value;
+		}
+		throw new Error("method arguments must be literals");
+	}
+
+	// 用 isCall 区分「空参调用 f()」与「属性访问 f」，二者 args 都为空数组
+	function parseArgs(): { isCall: boolean; args: unknown[] } {
+		if (tokens[i]?.kind !== "lparen") return { isCall: false, args: [] };
+		i++;
+		const args: unknown[] = [];
+		if (tokens[i]?.kind === "rparen") {
+			i++;
+			return { isCall: true, args };
+		}
+		for (;;) {
+			args.push(parseLiteral());
+			const next = tokens[i++];
+			if (next?.kind === "rparen") return { isCall: true, args };
+			if (next?.kind !== "comma") throw new Error("expected , or )");
+		}
+	}
+
+	const first = tokens[0];
+	if (!first || first.kind !== "ident") {
+		throw new Error("expression must start with an identifier");
+	}
+	// 根变量必须是上下文自身的属性，杜绝 ${constructor} 这类继承属性
+	if (!Object.prototype.hasOwnProperty.call(root, first.value)) {
+		throw new Error(`unknown variable: ${first.value}`);
+	}
+	let current: unknown = root[first.value];
+	i = 1;
+
+	while (i < tokens.length) {
+		if (tokens[i]?.kind !== "dot") throw new Error("expected .");
+		i++;
+		const id = tokens[i++];
+		if (!id || id.kind !== "ident") {
+			throw new Error("expected property name after .");
+		}
+		if (BLOCKED_PROPERTIES.has(id.value)) {
+			throw new Error(`blocked property: ${id.value}`);
+		}
+		const { isCall, args } = parseArgs();
+		if (current === undefined || current === null) return undefined;
+		const receiver = current as Record<string, unknown>;
+		if (isCall) {
+			const fn = receiver[id.value];
+			if (typeof fn !== "function") {
+				throw new Error(`${id.value} is not a function`);
+			}
+			current = (fn as (...fnArgs: unknown[]) => unknown).apply(
+				receiver,
+				args
+			);
+		} else {
+			current = receiver[id.value];
+		}
+	}
+	return current;
+}
+
+/**
+ * 求值失败（语法越界、未知变量、运行时异常）统一返回 undefined，
+ * 由调用方决定兜底行为（原样保留占位符）。
+ */
+export function safeEvaluate(
+	expr: string,
+	root: Record<string, unknown>
+): unknown {
+	const tokens = tokenize(expr);
+	if (!tokens || tokens.length === 0) return undefined;
+	try {
+		return evaluate(tokens, root);
+	} catch {
+		return undefined;
+	}
+}

--- a/src/manager/variable/variableHandler.ts
+++ b/src/manager/variable/variableHandler.ts
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 import { App, TFile } from "obsidian";
+import { safeEvaluate } from "./expressionEvaluator";
 
 export class VariableContext {
 	[key: string]: any;
@@ -36,14 +37,16 @@ export default class DefaultVariableHandler {
 	static handle(input: string, app: App, file: TFile, attachment?: File, index?: number): string {
 		if (input == undefined || input == null || input.trim() == "") return input;
 
-		// eslint-disable-next-line
 		const context = VariableContext.fromFile(app, file, attachment);
 		const placeholderRegex = /\${(.*?)}/g;
 		const replacedText = input.replace(
 			placeholderRegex,
-			(_, placeholder) => {
-				const value = eval(`context.${placeholder.trim()}`);
-				return value !== undefined ? String(value) : placeholder;
+			(match, placeholder) => {
+				const value = safeEvaluate(placeholder.trim(), context);
+				// 求值失败时原样保留 ${...} 占位符，避免静默丢失用户配置
+				return value !== undefined && value !== null
+					? String(value)
+					: match;
 			}
 		);
 

--- a/src/ui/attachments/AttachmentView.tsx
+++ b/src/ui/attachments/AttachmentView.tsx
@@ -124,7 +124,6 @@ export default function AttachmentView({
 		if (!attachments) {
 			return [];
 		}
-		console.log(filter);
 		return attachments
 			.filter((attachment) => {
 				if (filter.name !== "") {

--- a/src/ui/form/SettingForm.tsx
+++ b/src/ui/form/SettingForm.tsx
@@ -74,15 +74,15 @@ export function SettingForm(props: {
 	};
 
 	const onRuleAdd = () => {
-		const newRules = [...config.rules, new DefaultRule()];
+		const rule = new DefaultRule();
+		// 新规则排在现有规则之后执行
+		rule.sort =
+			Math.max(-1, ...config.rules.map((item) => item.sort ?? 0)) + 1;
 		const newConfig = {
 			...config,
-			rules: newRules,
+			rules: [...config.rules, rule],
 		};
-		setConfig({
-			...config,
-			rules: newRules,
-		});
+		setConfig(newConfig);
 		onChange(newConfig);
 	};
 
@@ -97,7 +97,8 @@ export function SettingForm(props: {
 			}
 			const newConfig = {
 				...config,
-				rules: newRules,
+				// 重排后将 sort 与展示顺序对齐，保证执行优先级与 UI 一致
+				rules: newRules.map((rule, i) => ({ ...rule, sort: i })),
 			};
 			setConfig(newConfig);
 			onChange(newConfig);

--- a/src/ui/reactSettingTab.tsx
+++ b/src/ui/reactSettingTab.tsx
@@ -43,7 +43,7 @@ export default class ReactAttachmentSettingTab extends PluginSettingTab {
 
 export const repositoryOptions = [
 	{
-		value: "VAULT_SUBFOLDER",
+		value: "ROOT_FOLDER",
 		label: getLocal().FILE_POSITION_TYPE_ROOT,
 	},
 	{

--- a/src/ui/suggestOptions.tsx
+++ b/src/ui/suggestOptions.tsx
@@ -126,7 +126,7 @@ export function getTagOptions(inputStr: string, app: App): SuggestItem[] {
 	const lowerCaseInputStr = inputStr.toLowerCase();
 	abstractFiles.forEach((file: TAbstractFile) => {
 		if (file instanceof TFile) {
-			const cache = this.app.metadataCache.getCache(file.path);
+			const cache = app.metadataCache.getCache(file.path);
 			if (cache) {
 				const fileTags = getAllTags(cache);
 				fileTags?.forEach((tag) => {


### PR DESCRIPTION
## 概述

本 PR 集中修复近期发现的若干缺陷，并移除变量占位符解析中的 `eval` 调用，改用受控表达式求值器。涉及配置兼容性、规则执行顺序、未用附件扫描与一处 UI 崩溃，均为修复性改动，无新功能。

## 改动内容

### 🐛 缺陷修复

- **标签建议崩溃** (`src/ui/suggestOptions.tsx`)
  `getTagOptions` 为普通函数，`this.app` 为 `undefined` 导致获取标签建议时崩溃。改为直接使用 `app` 形参。

- **配置值不一致导致附件被静默丢弃** (`src/main.ts`, `src/manager/migrate.ts`, `src/ui/reactSettingTab.tsx`)
  历史版本设置面板写入的 `repository.type` 为 `"VAULT_SUBFOLDER"`，而仓库匹配端判断的是 `"ROOT_FOLDER"`，二者不一致会使规则失效。新增幂等的 `migrateConfig()` 在加载配置后统一迁移坏值、按 `sort` 稳定排序规则，并在产生变化时落盘。同步修正设置面板的下拉值。

- **未用附件扫描的 null 污染与 O(n²) 判重** (`src/handler/attachmentsHandler.ts`)
  重写 `listUnusedAttachments`：直接用 `resolvedLinks` 内层 key 构造 `Set<string>` 按路径判重，消除 `getAbstractFileByPath` 返回 `null` 污染集合的问题，并去掉冗余索引与数组 `includes`。`console.log` 一并替换为统一的 `log`。

- **规则未按 sort 执行、UI 不维护 sort 字段** (`src/manager/attachmentManager.ts`, `src/ui/form/SettingForm.tsx`)
  执行路径对启用规则按 `sort` 稳定排序；新增规则时赋予排在末尾的 `sort`；拖动重排后用序号回写 `sort`，保证执行优先级与展示顺序一致。

### 🔒 安全

- **用受控求值器替换 `eval`** (`src/manager/variable/expressionEvaluator.ts`, `src/manager/variable/variableHandler.ts`, `scripts/esbuild.config.mjs`)
  新增 `expressionEvaluator.ts`，仅支持属性访问与方法调用（参数限字面量），屏蔽 `constructor`/`__proto__`/`prototype` 等原型链逃逸路径，根变量须为上下文自身属性。求值失败时原样保留 `${...}` 占位符而非静默丢失配置。同时移除 esbuild 的 `direct-eval` 日志压制。

### 🧹 杂项

- 清理 `AttachmentView.tsx` 中遗留的 `console.log(filter)`。
- 补充 `@eslint/js` 依赖并新增 `lint` 脚本。

## 变更类型

- [x] Bug 修复（非破坏性）
- [x] 安全加固
- [ ] 新功能
- [ ] 破坏性变更

## 自测说明

- 配置含历史 `VAULT_SUBFOLDER` 值的仓库：加载后自动迁移为 `ROOT_FOLDER`，附件规则恢复正常匹配，再次加载保持幂等。
- 设置面板新增/拖动规则后，重启插件确认执行顺序与 UI 一致。
- 含 `${file.name}` 等占位符的路径模板正常解析；构造非法表达式（如 `${file.constructor}`）被拒绝且保留原占位符。
- 「列出未用附件」不再误判，无异常日志。