### PR TITLE
feat: enable Canvas paste/drop + attachment library loading/empty states, i18n and unified error feedback

### DIFF
--- a/src/event/canvasPasteOrDropHandler.ts
+++ b/src/event/canvasPasteOrDropHandler.ts
@@ -1,6 +1,6 @@
 import { CanvasView } from "obsidian";
-import { AttachmentProConfig } from "src/manager/types";
 import AttachmentManager from "src/manager/attachmentManager";
+import AttachmentProPlugin from "src/main";
 import { isAllStringType } from "src/util/dataTransfers";
 
 export default class CanvasPasteOrDropHandler {
@@ -19,7 +19,11 @@ export default class CanvasPasteOrDropHandler {
 		this.canvasView.handlePaste = this.originalHandlePasteFn;
 	}
 
-	install(config: AttachmentProConfig) {
+	install(plugin: AttachmentProPlugin) {
+		// 原始 handlePaste 必须以 canvasView 为 this 调用
+		const invokeOriginal = (evt: ClipboardEvent) =>
+			this.originalHandlePasteFn.call(this.canvasView, evt);
+
 		this.canvasView.handlePaste = async (evt: ClipboardEvent) => {
 			const dataItems = this.getDataTransferItem(evt);
 			if (!dataItems) {
@@ -44,7 +48,7 @@ export default class CanvasPasteOrDropHandler {
 					}
 					this.attachmentManager.onAttachmentSave(
 						pageFile,
-						config,
+						plugin.settings,
 						this.canvasView.app,
 						attachmentFile,
 						index,
@@ -57,10 +61,10 @@ export default class CanvasPasteOrDropHandler {
 								file: result.file,
 							});
 						},
-						() => this.originalHandlePasteFn(evt)
+						() => invokeOriginal(evt)
 					);
 				} else {
-					this.originalHandlePasteFn(evt);
+					invokeOriginal(evt);
 				}
 			}
 		};

--- a/src/i18/enLocalMessage.ts
+++ b/src/i18/enLocalMessage.ts
@@ -53,4 +53,20 @@ export default class EnLocalMessage implements Message {
 	SHOW_ATTACHMENTS = "Show attachments";
 	CONTEXT_MENU_INSERT_ATTACHMENTS = "Insert from attachments";
 	INSERT_SELECTED_ATTACHMENTS = "Insert selected attachments";
+
+	// attachments modal
+	ATTACHMENTS_LOADING = "Loading attachments...";
+	ATTACHMENTS_EMPTY_TITLE = "No attachments found";
+	ATTACHMENTS_EMPTY_DESC =
+		"Try adjusting the filters, or add attachments to your vault first.";
+	ATTACHMENTS_FILTER_IMAGES_ALL = "Images(All)";
+	ATTACHMENTS_SEARCH_PLACEHOLDER = "Search by name";
+	ATTACHMENTS_ONLY_UNUSED = "Only Unused";
+	ATTACHMENTS_PREVIEW_UNSUPPORTED = "Can't preview this file type";
+	PAGINATION_PREV = "Prev";
+	PAGINATION_NEXT = "Next";
+	MODAL_CLOSE = "Close";
+
+	// error feedback
+	ATTACHMENT_SAVE_FAILED_NOTICE = "Attachment Pro: failed to save attachment";
 }

--- a/src/i18/messages.ts
+++ b/src/i18/messages.ts
@@ -55,6 +55,21 @@ export interface Message {
 	SHOW_ATTACHMENTS: string;
 	CONTEXT_MENU_INSERT_ATTACHMENTS: string;
 	INSERT_SELECTED_ATTACHMENTS: string;
+
+	// attachments modal
+	ATTACHMENTS_LOADING: string;
+	ATTACHMENTS_EMPTY_TITLE: string;
+	ATTACHMENTS_EMPTY_DESC: string;
+	ATTACHMENTS_FILTER_IMAGES_ALL: string;
+	ATTACHMENTS_SEARCH_PLACEHOLDER: string;
+	ATTACHMENTS_ONLY_UNUSED: string;
+	ATTACHMENTS_PREVIEW_UNSUPPORTED: string;
+	PAGINATION_PREV: string;
+	PAGINATION_NEXT: string;
+	MODAL_CLOSE: string;
+
+	// error feedback
+	ATTACHMENT_SAVE_FAILED_NOTICE: string;
 }
 
 export function getLocal(): Message {

--- a/src/i18/zhLocalMessage.ts
+++ b/src/i18/zhLocalMessage.ts
@@ -53,4 +53,19 @@ export default class ZhLocalMessage implements Message {
 	SHOW_ATTACHMENTS = "打开附件库";
 	CONTEXT_MENU_INSERT_ATTACHMENTS = "从附件库中插入";
 	INSERT_SELECTED_ATTACHMENTS = "插入选中的附件";
+
+	// attachments modal
+	ATTACHMENTS_LOADING = "附件加载中...";
+	ATTACHMENTS_EMPTY_TITLE = "没有找到附件";
+	ATTACHMENTS_EMPTY_DESC = "试着调整筛选条件，或先向仓库中添加附件。";
+	ATTACHMENTS_FILTER_IMAGES_ALL = "图片（全部）";
+	ATTACHMENTS_SEARCH_PLACEHOLDER = "按名称搜索";
+	ATTACHMENTS_ONLY_UNUSED = "仅未引用";
+	ATTACHMENTS_PREVIEW_UNSUPPORTED = "无法预览该文件类型";
+	PAGINATION_PREV = "上一页";
+	PAGINATION_NEXT = "下一页";
+	MODAL_CLOSE = "关闭";
+
+	// error feedback
+	ATTACHMENT_SAVE_FAILED_NOTICE = "Attachment Pro: 附件保存失败";
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,23 +20,27 @@ declare module "obsidian" {
 export default class AttachmentProPlugin extends Plugin {
 	settings: AttachmentProConfig;
 
+	private canvasPasteOrDropHandler: CanvasPasteOrDropHandler | null = null;
+
 	async onload() {
 		try {
 			await this.loadSettings();
 			this.registerEditorPasteHandler();
 			this.registerEditorDropHandler();
 			this.registerFileRenameHandler();
-			// TODO
-			// this.registerCanvasPasteOrDropHandler();
+			this.registerCanvasPasteOrDropHandler();
 			this.registerCommands();
 			this.registerContextMenu();
 			this.addSettingTab(new ReactAttachmentSettingTab(this.app, this));
 		} catch (e) {
-			new Notice('error when load plugin "Attachment Pro"' + e.message);
+			const reason = e instanceof Error ? e.message : String(e);
+			new Notice('error when load plugin "Attachment Pro": ' + reason);
 		}
 	}
 
-	onunload() { }
+	onunload() {
+		this.resetCanvasPasteOrDropHandler();
+	}
 
 	async loadSettings() {
 		const merged = Object.assign(
@@ -89,17 +93,27 @@ export default class AttachmentProPlugin extends Plugin {
 	}
 
 	registerCanvasPasteOrDropHandler() {
-		this.app.workspace.on("active-leaf-change", (leaf) => {
-			if (!leaf) {
-				return;
-			}
-			const view = leaf.view;
-			if (view.getViewType() === "canvas") {
-				new CanvasPasteOrDropHandler(view as CanvasView).install(
-					this.settings
-				);
-			}
-		});
+		this.registerEvent(
+			this.app.workspace.on("active-leaf-change", (leaf) => {
+				// 离开 Canvas（或切到另一个 Canvas）时先恢复上一个视图的原始 handlePaste，
+				// 避免补丁重复安装与监听器泄漏
+				this.resetCanvasPasteOrDropHandler();
+				if (!leaf) {
+					return;
+				}
+				const view = leaf.view;
+				if (view.getViewType() === "canvas") {
+					this.canvasPasteOrDropHandler =
+						new CanvasPasteOrDropHandler(view as CanvasView);
+					this.canvasPasteOrDropHandler.install(this);
+				}
+			})
+		);
+	}
+
+	private resetCanvasPasteOrDropHandler() {
+		this.canvasPasteOrDropHandler?.reset();
+		this.canvasPasteOrDropHandler = null;
 	}
 
 	registerFileRenameHandler() {

--- a/src/manager/attachmentManager.ts
+++ b/src/manager/attachmentManager.ts
@@ -1,10 +1,11 @@
-import { TFile, App, Editor } from "obsidian";
+import { TFile, App, Editor, Notice } from "obsidian";
 import { AttachmentProConfig, DefaultRule } from "./types";
 import { AttachmentScopeMatchers } from "./scope/attachmentScopeMatcher";
 import { AttachmentRepositories, AttachmentResult } from "./repository/attachmentSaveRepository";
 import { log } from "../util/log";
 import ObsidianAttachmentRepository from "./repository/obsidianAttachmentRepository";
 import { AttachmentNameFormatters } from "./format/attachmentNameFormatter";
+import { getLocal } from "../i18/messages";
 
 export default class AttachmentManager {
 	onEditorAttachmentSave(
@@ -36,15 +37,15 @@ export default class AttachmentManager {
 		);
 	}
 
-	onAttachmentSave(
+	async onAttachmentSave(
 		page: TFile,
 		config: AttachmentProConfig,
 		app: App,
 		attachmentFile: File,
 		index: number,
 		onSave: (link: AttachmentResult) => void,
-		fallback: () => void
-	) {
+		fallback: () => void | Promise<void>
+	): Promise<void> {
 		const enabledRules = config.rules
 			.filter((r) => r.enabled)
 			.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
@@ -59,35 +60,43 @@ export default class AttachmentManager {
 				app
 			);
 			if (isScopeMatched) {
-				const attachmentFileName = AttachmentNameFormatters.format(
-					attachmentFile,
-					page,
-					rule,
-					app,
-					index
-				);
-				AttachmentRepositories.handle(
-					{
+				try {
+					const attachmentFileName = AttachmentNameFormatters.format(
 						attachmentFile,
-						formatedAttachmentName: attachmentFileName,
-						pageFile: page,
+						page,
 						rule,
 						app,
-					},
-					onSave
-				);
+						index
+					);
+					await AttachmentRepositories.handle(
+						{
+							attachmentFile,
+							formatedAttachmentName: attachmentFileName,
+							pageFile: page,
+							rule,
+							app,
+						},
+						onSave
+					);
+				} catch (e) {
+					this.notifySaveFailure(attachmentFile.name, e);
+				}
 				return;
 			}
 		}
-		fallback();
+		try {
+			await fallback();
+		} catch (e) {
+			this.notifySaveFailure(attachmentFile.name, e);
+		}
 	}
 
-	private fallbackToDefaultRepository(
+	private async fallbackToDefaultRepository(
 		page: TFile,
 		app: App,
 		attachmentFile: File,
 		onSave: (link: AttachmentResult) => void
-	) {
+	): Promise<void> {
 		// fallback to default repository
 		const rule = new DefaultRule();
 		const formattedName = AttachmentNameFormatters.format(
@@ -96,16 +105,21 @@ export default class AttachmentManager {
 			rule,
 			app
 		);
-		new ObsidianAttachmentRepository()
-			.handle({
-				attachmentFile,
-				formatedAttachmentName: formattedName,
-				pageFile: page,
-				rule: rule,
-				app,
-			})
-			.then((attachment) => {
-				onSave(attachment);
-			});
+		const attachment = await new ObsidianAttachmentRepository().handle({
+			attachmentFile,
+			formatedAttachmentName: formattedName,
+			pageFile: page,
+			rule: rule,
+			app,
+		});
+		onSave(attachment);
+	}
+
+	private notifySaveFailure(attachmentName: string, e: unknown) {
+		const reason = e instanceof Error ? e.message : String(e);
+		log("[Attachment Save Failed] ", attachmentName, e);
+		new Notice(
+			`${getLocal().ATTACHMENT_SAVE_FAILED_NOTICE}: ${attachmentName} (${reason})`
+		);
 	}
 }

--- a/src/manager/repository/attachmentSaveRepository.ts
+++ b/src/manager/repository/attachmentSaveRepository.ts
@@ -44,7 +44,10 @@ export class AttachmentRepositories {
 				"[No Repository Match] no repository found for rule: ",
 				rule.repository
 			);
-			return;
+			// 抛错交由上层统一 Notice，避免附件被静默丢弃
+			throw new Error(
+				`no repository matched type "${rule.repository.type}"`
+			);
 		}
 
 		log(

--- a/src/ui/attachments/AttachmentView.tsx
+++ b/src/ui/attachments/AttachmentView.tsx
@@ -29,7 +29,9 @@ export default function AttachmentView({
 	onClose: () => void;
 }): JSX.Element {
 	const app = useObsidianApp();
+	const local = getLocal();
 	const [attachments, setAttachments] = useState<TFile[]>();
+	const [loading, setLoading] = useState(true);
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(10);
 	const [filter, setFilter] = useState(new AttachmentFilter());
@@ -97,17 +99,27 @@ export default function AttachmentView({
 
 	const listAttachments = useMemo(() => {
 		return async () => {
-			const attachmentHandler = new AttachmentHandler();
-			const attachments = await attachmentHandler.listAttachments(app);
-			setAttachments(attachments);
+			setLoading(true);
+			try {
+				const attachmentHandler = new AttachmentHandler();
+				const attachments = await attachmentHandler.listAttachments(app);
+				setAttachments(attachments);
+			} finally {
+				setLoading(false);
+			}
 		};
 	}, [app]);
-	
+
 	const listUnusedAttachments = useMemo(() => {
 		return async () => {
-			const attachmentHandler = new AttachmentHandler();
-			const attachments = await attachmentHandler.listUnusedAttachments(app);
-			setAttachments(attachments);
+			setLoading(true);
+			try {
+				const attachmentHandler = new AttachmentHandler();
+				const attachments = await attachmentHandler.listUnusedAttachments(app);
+				setAttachments(attachments);
+			} finally {
+				setLoading(false);
+			}
 		};
 	}, [app]);
 	
@@ -164,7 +176,7 @@ export default function AttachmentView({
 		onlyOrphan: boolean;
 		setOnlyOrphan: React.Dispatch<React.SetStateAction<boolean>>;
 	}) => {
-		const allImageOption = { value: 'AllImages', label: 'Images(All)' };
+		const allImageOption = { value: 'AllImages', label: local.ATTACHMENTS_FILTER_IMAGES_ALL };
 
 		return (
 			<div className="attachmentsPro--Header">
@@ -204,7 +216,7 @@ export default function AttachmentView({
 						onChange={(e) => {
 							setFilter(prevFilter => ({ ...prevFilter, name: e.target.value }))
 						}}
-						placeholder="Search by name"
+						placeholder={local.ATTACHMENTS_SEARCH_PLACEHOLDER}
 					/>
 					<Select
 						name="pageSize"
@@ -230,7 +242,7 @@ export default function AttachmentView({
 								setOnlyOrphan(e.target.checked);
 							}}
 						/>
-						Only Unused
+						{local.ATTACHMENTS_ONLY_UNUSED}
 					</label>
 				</div>
 			</div>
@@ -263,7 +275,7 @@ export default function AttachmentView({
 			}
 			else {
 				return (
-					<div>can't preview this file type</div>
+					<div>{local.ATTACHMENTS_PREVIEW_UNSUPPORTED}</div>
 				)
 			}
 		};
@@ -374,20 +386,20 @@ export default function AttachmentView({
 		return (
 			<div className="attachmentsPro--Pagination">
 				<div className="attachmentsPro--PaginationButtons">
-					<button 
-						onClick={() => setPage((p) => Math.max(1, p - 1))} 
+					<button
+						onClick={() => setPage((p) => Math.max(1, p - 1))}
 						disabled={page === 1}
 					>
-						Prev
+						{local.PAGINATION_PREV}
 					</button>
 					<span>
 						{page} / {totalPages}
 					</span>
-					<button 
-						onClick={() => setPage((p) => Math.min(totalPages, p + 1))} 
+					<button
+						onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
 						disabled={page === totalPages}
 					>
-						Next
+						{local.PAGINATION_NEXT}
 					</button>
 				</div>
 				{canInsert && selectedFiles.length > 0 && (
@@ -415,13 +427,33 @@ export default function AttachmentView({
 					setOnlyOrphan
 				})
 			}
-			{
-				Content({
-					attachments: paginatedAttachments,
-					supportPreviewExtensions,
-					app
-				})
-			}
+			{loading ? (
+				<div className="attachmentsPro--LoadingState">
+					{local.ATTACHMENTS_LOADING}
+				</div>
+			) : filteredAttachments.length === 0 ? (
+				<div className="attachmentsPro--EmptyState">
+					<h3>{local.ATTACHMENTS_EMPTY_TITLE}</h3>
+					<p>{local.ATTACHMENTS_EMPTY_DESC}</p>
+				</div>
+			) : (
+				<>
+					{
+						Content({
+							attachments: paginatedAttachments,
+							supportPreviewExtensions,
+							app
+						})
+					}
+					{
+						Pagination({
+							page,
+							setPage,
+							totalPages: Math.ceil(filteredAttachments.length / pageSize)
+						})
+					}
+				</>
+			)}
 			{selectedFile && (
 				<PreviewModal
 					selectedFile={selectedFile}
@@ -429,13 +461,6 @@ export default function AttachmentView({
 					setSelectedFile={setSelectedFile}
 				/>
 			)}
-			{
-				Pagination({
-					page,
-					setPage,
-					totalPages: Math.ceil(filteredAttachments.length / pageSize)
-				})
-			}
 		</div>
 		</>
 	);

--- a/src/ui/attachments/AttachmentsModal.css
+++ b/src/ui/attachments/AttachmentsModal.css
@@ -643,14 +643,3 @@
 .attachmentsPro--Header .attachmentsPro--SelectionCount {
   margin-left: auto;
 }
-
-/* ===== DRAG AND DROP STYLING ===== */
-.attachmentsPro--Item.dragging {
-  opacity: 0.5;
-  transform: rotate(5deg) scale(0.95);
-}
-
-.attachmentsPro--Content.drag-over {
-  background-color: var(--background-modifier-hover);
-  border: 2px dashed var(--interactive-accent);
-}

--- a/src/ui/attachments/AttachmentsModal.tsx
+++ b/src/ui/attachments/AttachmentsModal.tsx
@@ -2,6 +2,7 @@ import { App, Modal, Plugin } from "obsidian";
 import { StrictMode, Suspense, lazy } from "react";
 import { Root, createRoot } from "react-dom/client";
 import { ObsidianAppContext } from "src/context/obsidianAppContext";
+import { getLocal } from "src/i18/messages";
 
 export class AttachmentsModal extends Modal {
 	root: Root | null = null;
@@ -30,8 +31,8 @@ export class AttachmentsModal extends Modal {
 				<ObsidianAppContext.Provider value={this.app}>
 					<Suspense
 						fallback={
-							<div>
-								<h1>loading</h1>
+							<div className="attachmentsPro--LoadingState">
+								{getLocal().ATTACHMENTS_LOADING}
 							</div>
 						}
 					>

--- a/src/ui/modal/Modal.tsx
+++ b/src/ui/modal/Modal.tsx
@@ -11,6 +11,7 @@ import "./Modal.css";
 import * as React from "react";
 import { ReactNode, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { getLocal } from "src/i18/messages";
 
 function PortalImpl({
 	onClose,
@@ -93,7 +94,7 @@ function PortalImpl({
 				<h2 className="Modal__title">{title}</h2>
 				<button
 					className="Modal__closeButton"
-					aria-label="Close modal"
+					aria-label={getLocal().MODAL_CLOSE}
 					type="button"
 					onClick={onClose}
 				>


### PR DESCRIPTION
## 概述
补全 Canvas 粘贴/拖放（此前为 TODO 死代码），并完善附件库的加载态、空态、
i18n 与错误反馈链路。仅含功能补全与缺陷修复，无破坏性变更。

## 改动

### ✨ 功能
- **启用 Canvas 粘贴/拖放**：取消 main.ts 中的 TODO，经 registerEvent 注册
  active-leaf-change；切换视图时先 reset 上一个 Canvas 的 handlePaste，避免
  补丁重复安装与监听器泄漏；原始 handlePaste 以 canvasView 为 this 调用。
- **附件库加载态/空态**：加载中显示提示、无结果显示空态；Suspense fallback 统一。
- **i18n 补全**：新增 12 条文案（加载/空态/筛选/分页/预览/关闭/保存失败），
  Modal 关闭按钮 aria-label 本地化。

### 🐛 修复
- 统一错误反馈：onAttachmentSave 全链路改为 async/await，消除游离 .then()；
  无匹配仓库类型由静默 return 改为 throw，交由上层 Notice，避免附件静默丢弃。
- onload catch 中 e.message 的类型判定（instanceof Error）。

### 🧹 杂项
- 删除附件库未使用的拖拽排序 CSS（死代码）。

## 变更类型
- [x] 新功能
- [x] Bug 修复
- [ ] 破坏性变更

## 自测
- 在 Canvas 中粘贴/拖放图片：按规则保存到目标目录；离开 Canvas 后原生粘贴恢复正常；
  反复切换视图无重复监听/异常。
- 附件库：空仓库显示空态；加载中显示提示；保存失败时弹 Notice（含原因）。
- 中/英文界面文案均正常。