### PR TITLE
fix: clear eslint-plugin-obsidianmd lint errors across the codebase

### DIFF
--- a/src/event/canvasPasteOrDropHandler.ts
+++ b/src/event/canvasPasteOrDropHandler.ts
@@ -46,7 +46,7 @@ export default class CanvasPasteOrDropHandler {
 					if (!attachmentFile) {
 						continue;
 					}
-					this.attachmentManager.onAttachmentSave(
+					void this.attachmentManager.onAttachmentSave(
 						pageFile,
 						plugin.settings,
 						this.canvasView.app,

--- a/src/event/canvasPasteOrDropHandler.ts
+++ b/src/event/canvasPasteOrDropHandler.ts
@@ -21,9 +21,10 @@ export default class CanvasPasteOrDropHandler {
 
 	install(plugin: AttachmentProPlugin) {
 		// 原始 handlePaste 必须以 canvasView 为 this 调用
-		const invokeOriginal = (evt: ClipboardEvent) =>
-			this.originalHandlePasteFn.call(this.canvasView, evt);
-
+		const invokeOriginal = (evt: ClipboardEvent): void => {
+			this.originalHandlePasteFn.call(this.canvasView, evt);	
+		}
+			
 		this.canvasView.handlePaste = async (evt: ClipboardEvent) => {
 			const dataItems = this.getDataTransferItem(evt);
 			if (!dataItems) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,21 +11,6 @@ import '../style/suggest.css'
 import { AttachmentsModal } from "./ui/attachments/AttachmentsModal";
 import { getLocal } from "./i18/messages";
 
-declare module "obsidian" {
-	interface CanvasView extends TextFileView {
-		handlePaste: (e: ClipboardEvent) => Promise<void>;
-		/** Obsidian 未公开的 Canvas 内部对象，仅声明本插件用到的成员 */
-		canvas: {
-			posCenter(): { x: number; y: number };
-			createFileNode(options: {
-				pos: { x: number; y: number };
-				position: string;
-				file: TFile;
-			}): unknown;
-		};
-	}
-}
-
 export default class AttachmentProPlugin extends Plugin {
 	settings: AttachmentProConfig;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,18 +52,17 @@ export default class AttachmentProPlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		const merged = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			await this.loadData()
-		);
-		this.settings = migrateConfig(merged);
-		if (JSON.stringify(this.settings) !== JSON.stringify(merged)) {
-			// 迁移产生了变化，落盘避免坏值残留在 data.json
-			await this.saveData(this.settings);
-		}
-		log("[Config] loading plugins", this.settings);
-	}
+    const loaded = (await this.loadData()) as Partial<AttachmentProConfig> | null;
+    const merged: AttachmentProConfig = {
+        ...DEFAULT_SETTINGS,
+        ...(loaded ?? {}),
+    };
+    this.settings = migrateConfig(merged);
+    if (JSON.stringify(this.settings) !== JSON.stringify(merged)) {
+        await this.saveData(this.settings);
+    }
+    log("[Config] loading plugins", this.settings);
+}
 
 	async saveSettings() {
 		await this.saveData(this.settings);

--- a/src/manager/attachmentManager.ts
+++ b/src/manager/attachmentManager.ts
@@ -15,7 +15,7 @@ export default class AttachmentManager {
 		attachmentFile: File,
 		index: number
 	) {
-		this.onAttachmentSave(
+		void this.onAttachmentSave(
 			page,
 			config,
 			app,

--- a/src/manager/obsidian-extend.d.ts
+++ b/src/manager/obsidian-extend.d.ts
@@ -1,0 +1,16 @@
+import { TextFileView, TFile } from "obsidian";
+
+declare module "obsidian" {
+  interface CanvasView extends TextFileView {
+    handlePaste: (e: ClipboardEvent) => Promise<void>;
+    /** Obsidian 未公开的 Canvas 内部对象，仅声明本插件用到的成员 */
+    canvas: {
+      posCenter(): { x: number; y: number };
+      createFileNode(options: {
+        pos: { x: number; y: number };
+        position: string;
+        file: TFile;
+      }): unknown;
+    };
+  }
+}

--- a/src/manager/scope/fileTagAttachmentScopeMatcher.ts
+++ b/src/manager/scope/fileTagAttachmentScopeMatcher.ts
@@ -33,9 +33,9 @@ export default class FileTagAttachmentScopeMatcher
 
 		// merge tags from frontmatter
 		if (fileCache.frontmatter) {
-			const tags = fileCache.frontmatter["tags"];
+			const tags: unknown = fileCache.frontmatter["tags"];
 			if (Array.isArray(tags)) {
-				allTags.push(...tags.map(String));
+				allTags.push(...(tags as unknown[]).map(String));
 			} else if (typeof tags === "string") {
 				allTags.push(...tags.split(",").map((t) => t.trim()));
 			}

--- a/src/manager/variable/variableHandler.ts
+++ b/src/manager/variable/variableHandler.ts
@@ -3,7 +3,7 @@ import { App, TFile } from "obsidian";
 import { safeEvaluate } from "./expressionEvaluator";
 
 export class VariableContext {
-	[key: string]: any;
+	[key: string]: unknown;
 
 	static fromFile(app: App, file: TFile, attachment?: File): VariableContext {
 		const context = new VariableContext();
@@ -41,7 +41,7 @@ export default class DefaultVariableHandler {
 		const placeholderRegex = /\${(.*?)}/g;
 		const replacedText = input.replace(
 			placeholderRegex,
-			(match, placeholder) => {
+			(match, placeholder: string) => {
 				const value = safeEvaluate(placeholder.trim(), context);
 				// 求值失败时原样保留 ${...} 占位符，避免静默丢失用户配置
 				return value !== undefined && value !== null

--- a/src/manager/variable/variableHandler.ts
+++ b/src/manager/variable/variableHandler.ts
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import { App, TFile } from "obsidian";
 import { safeEvaluate } from "./expressionEvaluator";
+import { safeStringify } from "@src/util/safeStringify";
 
 export class VariableContext {
 	[key: string]: unknown;
@@ -43,10 +44,9 @@ export default class DefaultVariableHandler {
 			placeholderRegex,
 			(match, placeholder: string) => {
 				const value = safeEvaluate(placeholder.trim(), context);
-				// 求值失败时原样保留 ${...} 占位符，避免静默丢失用户配置
-				return value !== undefined && value !== null
-					? String(value)
-					: match;
+				// 求值失败或结果无法转成有意义文本时，原样保留 ${...}
+				// 占位符，避免静默丢失用户配置
+				return safeStringify(value) ?? match;
 			}
 		);
 

--- a/src/ui/attachments/AttachmentView.tsx
+++ b/src/ui/attachments/AttachmentView.tsx
@@ -1,5 +1,5 @@
 import { App, MarkdownView, TFile } from "obsidian";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useObsidianApp } from "src/context/obsidianAppContext";
 import { AttachmentHandler } from "src/handler/attachmentsHandler";
 import { File } from "lucide-react";
@@ -299,7 +299,7 @@ export default function AttachmentView({
 }: {
 	canInsert?: boolean,
 	onClose: () => void;
-}): JSX.Element {
+}): ReactNode {
 	const app = useObsidianApp();
 	const local = getLocal();
 	const [attachments, setAttachments] = useState<TFile[]>();

--- a/src/ui/attachments/AttachmentView.tsx
+++ b/src/ui/attachments/AttachmentView.tsx
@@ -239,7 +239,7 @@ function Content(props: {
 							rel="noopener"
 							onClick={(e) => {
 								e.preventDefault();
-								app.workspace.openLinkText(attachment.name, attachment.path, true, { active: true });
+								void app.workspace.openLinkText(attachment.name, attachment.path, true, { active: true });
 							}}
 						>
 							{attachment.name}
@@ -361,7 +361,7 @@ export default function AttachmentView({
 	);
 
 	useEffect(() => {
-		listAttachments(filter.unused);
+		void listAttachments(filter.unused);
 	}, [filter.unused, listAttachments]);
 
 	// 任何筛选条件变化都回到第一页，避免停留在已不存在的页码上

--- a/src/ui/attachments/AttachmentsModal.tsx
+++ b/src/ui/attachments/AttachmentsModal.tsx
@@ -54,7 +54,7 @@ export class AttachmentsModal extends Modal {
 		);
 	}
 
-	async onClose() {
+	onClose() {
 		this.root?.unmount();
 		this.root = null;
 	}

--- a/src/ui/form/SettingForm.tsx
+++ b/src/ui/form/SettingForm.tsx
@@ -154,7 +154,7 @@ export function SettingForm(props: {
 			{showTooltip && (
 				<>
 					<div
-						ref={refs.setFloating}
+						ref={(node) => refs.setFloating(node)}
 						className="tooltip"
 						style={{
 							...floatingStyles,

--- a/src/ui/form/SettingForm.tsx
+++ b/src/ui/form/SettingForm.tsx
@@ -46,7 +46,7 @@ export function SettingForm(props: {
 	title: string;
 	config: AttachmentProConfig;
 	onChange: (config: AttachmentProConfig) => void;
-}): JSX.Element {
+}): ReactNode {
 	const app = useObsidianApp();
 	const { onChange } = props;
 	const [config, setConfig] = useState(props.config);
@@ -457,7 +457,7 @@ export function SettingForm(props: {
 function ScopeInputTag(props: {
 	scope: AttachmentScope;
 	onChange: (ranges: ScopeRangeItem[]) => void;
-}): JSX.Element {
+}): ReactNode {
 	const { scope } = props;
 	const local = getLocal();
 	const app = useObsidianApp();

--- a/src/ui/modal/Modal.tsx
+++ b/src/ui/modal/Modal.tsx
@@ -25,7 +25,7 @@ function PortalImpl({
 	onClose: () => void;
 	title: string;
 	modalContentSize: "auto" | "max";
-}): JSX.Element {
+}): ReactNode {
 	const modalRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -120,7 +120,7 @@ export default function Modal({
 	title: string;
 	modalContentSize?: "auto" | "max";
 	container?: HTMLElement;
-}): JSX.Element {
+}): ReactNode {
 	// 如果提供了容器，使用 createPortal 渲染到该容器
 	// 否则直接返回组件（不使用 Portal）
 	if (container) {

--- a/src/ui/modal/Modal.tsx
+++ b/src/ui/modal/Modal.tsx
@@ -36,7 +36,7 @@ function PortalImpl({
 	useEffect(() => {
 		let modalOverlayElement: HTMLElement | null = null;
 		const handler = (event: KeyboardEvent): void => {
-			if (event.keyCode === 27) {
+			if (event.key === "Escape") {
 				onClose();
 			}
 		};

--- a/src/ui/modal/Modal.tsx
+++ b/src/ui/modal/Modal.tsx
@@ -8,8 +8,7 @@
 
 import "./Modal.css";
 
-import * as React from "react";
-import { ReactNode, useEffect, useRef } from "react";
+import { CSSProperties, ReactNode, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { getLocal } from "src/i18/messages";
 
@@ -75,7 +74,7 @@ function PortalImpl({
 		};
 	}, [closeOnClickOutside, onClose]);
 
-	let modalContentStyle;
+	let modalContentStyle: CSSProperties;
 	if (modalContentSize === "max") {
 		modalContentStyle = {
 			flexGrow: 1,

--- a/src/ui/modal/useModal.tsx
+++ b/src/ui/modal/useModal.tsx
@@ -6,19 +6,19 @@
  *
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { ReactNode, useCallback, useMemo, useState } from "react";
 import Modal from "./Modal";
 
 export default function useModal(
 	afterClose?: () => void,
 	modalContentSize?: "auto" | "max"
 ): [
-	JSX.Element | null,
-	(title: string, showModal: (onClose: () => void) => JSX.Element) => void
+	ReactNode | null,
+	(title: string, showModal: (onClose: () => void) => ReactNode) => void
 ] {
 	const [modalContent, setModalContent] = useState<null | {
 		closeOnClickOutside: boolean;
-		content: JSX.Element;
+		content: ReactNode;
 		title: string;
 	}>(null);
 
@@ -50,7 +50,7 @@ export default function useModal(
 		(
 			title: string,
 			// eslint-disable-next-line no-shadow
-			getContent: (onClose: () => void) => JSX.Element,
+			getContent: (onClose: () => void) => ReactNode,
 			closeOnClickOutside = false
 		) => {
 			setModalContent({

--- a/src/ui/modal/useModal.tsx
+++ b/src/ui/modal/useModal.tsx
@@ -49,7 +49,6 @@ export default function useModal(
 	const showModal = useCallback(
 		(
 			title: string,
-			// eslint-disable-next-line no-shadow
 			getContent: (onClose: () => void) => ReactNode,
 			closeOnClickOutside = false
 		) => {

--- a/src/ui/suggest/Suggest.tsx
+++ b/src/ui/suggest/Suggest.tsx
@@ -12,7 +12,7 @@ import {
 } from "@floating-ui/react";
 import { debounce } from "obsidian";
 import * as React from "react";
-import { CSSProperties, useEffect, useLayoutEffect } from "react";
+import { CSSProperties, ReactNode, useEffect, useLayoutEffect } from "react";
 
 export function Suggest(props: {
 	query: string;
@@ -23,7 +23,7 @@ export function Suggest(props: {
 	anchorElement: Element;
 	onSelectChange?: (item: SuggestItem | null, index: number) => void;
 	style?: CSSProperties;
-}): JSX.Element {
+}): ReactNode {
 	const { query, onOpenChange, anchorElement, showSuggest } = props;
 	const [activeIndex, setActiveIndex] = React.useState<number>(-1);
 	const [items, setItems] = React.useState<SuggestItem[]>([]);

--- a/src/ui/suggest/Suggest.tsx
+++ b/src/ui/suggest/Suggest.tsx
@@ -124,7 +124,7 @@ export function Suggest(props: {
 			{showSuggest && items.length > 0 && (
 				<div
 					className="suggest-container"
-					ref={refs.setFloating}
+					ref={(node) => refs.setFloating(node)}
 					style={{
 						...floatingStyles,
 					}}

--- a/src/ui/suggest/SuggestInput.tsx
+++ b/src/ui/suggest/SuggestInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { CSSProperties } from "react";
+import { CSSProperties, ReactNode } from "react";
 import { getLocal } from "src/i18/messages";
 import { Suggest, SuggestItem } from "./Suggest";
 
@@ -10,7 +10,7 @@ export function SuggestInput(props: {
 	getItems: (query: string) => SuggestItem[];
 	defaultInputValue?: string;
 	style?: CSSProperties;
-}): JSX.Element {
+}): ReactNode {
 	const { inputPlaceholder } = props;
 	const [value, setValue] = React.useState(props.defaultInputValue);
 	const [showSuggest, setShowSuggest] = React.useState(false);

--- a/src/ui/tags/InputTags.tsx
+++ b/src/ui/tags/InputTags.tsx
@@ -47,7 +47,8 @@ export function InputTags(props: {
 			const value = inputRef.current?.value;
 			if (value) {
 				appendTag(value);
-				inputRef.current!.value = "";
+				const el = inputRef.current;
+				if (el) { el.value = ""; }
 			}
 		}
 	};

--- a/src/ui/tags/InputTags.tsx
+++ b/src/ui/tags/InputTags.tsx
@@ -14,7 +14,7 @@ export function InputTags(props: {
 	getItems?: (query: string) => SuggestItem[];
 	inputPlaceholder?: string;
 	excludeTriggerKeys?: string[];
-}): JSX.Element {
+}): ReactNode {
 	const [value, setValue] = useState("");
 	const [hasSelected, setHasSelected] = useState(false);
 	const [showSuggest, setShowSuggest] = useState(false);

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,15 +1,9 @@
 import { App, TFile, normalizePath } from "obsidian";
 import { log } from "./log";
 
-export function getParentFolderFromTFile(file: TFile) {
-	const pageParent = file.parent;
-	let pageParentFolder;
-	if (pageParent == null) {
-		pageParentFolder = "";
-	} else {
-		pageParentFolder = pageParent.path;
-	}
-	return pageParentFolder;
+export function getParentFolderFromTFile(file: TFile): string {
+    const pageParent = file.parent;
+    return pageParent == null ? "" : pageParent.path;
 }
 
 export async function createFolderIfNotExist(path: string, app: App) {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -1,10 +1,3 @@
-export const env = {
-	mode: "dev",
-}
-
 export function log(content: string, ...args: unknown[]): void {
-    if (env.mode !== "production") {
-        // 受控日志门面：仅开发模式输出，受 env.mode 统一开关
-        console.log(content, ...args);
-    }
+    console.debug(content, ...args);
 }

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -2,8 +2,9 @@ export const env = {
 	mode: "dev",
 }
 
-export function log(content: string, ...args: any) {
-	if (env.mode != "production") {
-		console.log(content, args);
-	}
+export function log(content: string, ...args: unknown[]): void {
+    if (env.mode !== "production") {
+        // 受控日志门面：仅开发模式输出，受 env.mode 统一开关
+        console.log(content, ...args);
+    }
 }

--- a/src/util/safeStringify.ts
+++ b/src/util/safeStringify.ts
@@ -1,11 +1,19 @@
-export function safeStringify(value: unknown): string {
+import { DateTime } from "luxon";
+
+export function safeStringify(value: unknown): string | undefined {
     if (typeof value === "string") return value;
-    if (typeof value === "number" || typeof value === "boolean") return String(value);
-    if (value === null) return "null";
-    // 对象/数组等：用 JSON 序列化，避免 [object Object]
-    try {
-        return JSON.stringify(value);
-    } catch {
+    if (typeof value === "number" || typeof value === "boolean") {
         return String(value);
     }
+    if (DateTime.isDateTime(value)) return value.toString();
+    if (Array.isArray(value)) {
+        const parts: string[] = [];
+        for (const item of value as unknown[]) {
+            const part = safeStringify(item);
+            if (part === undefined) return undefined;
+            parts.push(part);
+        }
+        return parts.join(",");
+    }
+    return undefined;
 }

--- a/src/util/safeStringify.ts
+++ b/src/util/safeStringify.ts
@@ -1,0 +1,11 @@
+export function safeStringify(value: unknown): string {
+    if (typeof value === "string") return value;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+    if (value === null) return "null";
+    // 对象/数组等：用 JSON 序列化，避免 [object Object]
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}

--- a/src/util/sort.ts
+++ b/src/util/sort.ts
@@ -1,4 +1,4 @@
-export function swapSave(arr: any[], current: number, next: number) {
+export function swapSave<T>(arr: T[], current: number, next: number): void {
     if (current < 0 || current >= arr.length || next < 0 || next >= arr.length) {
         return;
     }

--- a/test/variableHandler.test.ts
+++ b/test/variableHandler.test.ts
@@ -74,6 +74,20 @@ describe("DefaultVariableHandler.handle", () => {
 		).toBe("${frontmatter.created}");
 	});
 
+	it("结果为普通对象时保留占位符，而非 [object Object]", () => {
+		const app = mockApp({ frontmatter: { created: "2026-01-15" } });
+		expect(
+			DefaultVariableHandler.handle("${frontmatter}", app, pageFile)
+		).toBe("${frontmatter}");
+	});
+
+	it("结果为原始类型数组时用逗号连接", () => {
+		const app = mockApp({ frontmatter: { tags: ["a", "b"] } });
+		expect(
+			DefaultVariableHandler.handle("${frontmatter.tags}", app, pageFile)
+		).toBe("a,b");
+	});
+
 	it("index > 0 时追加两位序号后缀", () => {
 		expect(
 			DefaultVariableHandler.handle(


### PR DESCRIPTION
## 概述
清理 `eslint-plugin-obsidianmd` 在严格规则下报出的全部 lint 错误。绝大部分
改动仅涉及类型标注与 API 用法，零行为变化；唯一的对外可见变化是变量占位符
解析结果为对象时不再产出 `[object Object]`，而是保留原占位符（更正确，且已
补测试）。目标是通过 `pnpm lint` 检查。

## 改动清单

### 类型与规范
- **`JSX.Element` → `ReactNode`**：8 处组件返回类型改用 React 标准返回类型
  （新 eslint 配置下 `JSX` 命名空间不再全局可用）。
- **消除 `any` 扩散**：`VariableContext` 索引签名、`log()`、`swapSave<T>`、
  `loadSettings` 的 `loadData()` 返回、frontmatter tags 等改用 `unknown`/
  `Partial`/泛型收窄；`Modal` 的 style 补 `CSSProperties`。
- **多余断言**：`InputTags` 的 `inputRef.current!` 改为判空分支。
- **未使用 eslint-disable**：清理 `useModal` 中失效的 `no-shadow` 注释。

### 正确性修复（仍属 lint 驱动）
- **未处理的 Promise**：4 处 fire-and-forget 调用加 `void` 前缀。
- **未绑定的方法引用**：`ref={refs.setFloating}` → `ref={(node) => ...}`，
  修复 `this` 丢失。
- **`keyCode` 已弃用**：ESC 判断改用 `event.key === "Escape"`。
- **`declare module "obsidian"`**：`CanvasView` 扩展移到独立的
  `obsidian-extend.d.ts`，使扩展成员类型全局可见。

### 变量解析改进（附测试）
- 新增 `util/safeStringify`：`${...}` 求值为对象时保留原占位符而非
  `[object Object]`；原始类型数组用逗号连接。新增 2 个单测覆盖。
- `log()` 简化为 `console.debug`，移除写死的 `env.mode` 门面（生产构建由
  esbuild `drop: ["console"]` 控制）。

## 变更类型
- [x] Bug 修复 / 代码规范
- [ ] 新功能
- [ ] 破坏性变更

## 自测
- `pnpm lint` 无错误。
- `pnpm test` 全部通过（含新增的 `safeStringify` 相关用例）。
- 附件粘贴/拖放、设置面板、附件库、Suggest 弹层回归正常。